### PR TITLE
Fixing issue for installing kaliveda exec on mac

### DIFF
--- a/execs/CMakeLists.txt
+++ b/execs/CMakeLists.txt
@@ -45,5 +45,9 @@ endforeach()
 install(TARGETS ${build_targets} EXPORT ${CMAKE_PROJECT_NAME}Exports RUNTIME DESTINATION bin)
 
 #---install shell scripts
-set(scripts KVA KaliVeda)
-install(PROGRAMS ${scripts} DESTINATION bin)
+if(APPLE)
+    message(STATUS "You're on a MAC? - Skipping install shell scripts... sorry !")
+else()
+    set(scripts KVA KaliVeda)
+    install(PROGRAMS ${scripts} DESTINATION bin)
+endif()


### PR DESCRIPTION
Add flag on "APPLE" to not install shell stuffs if kaliveda on mac because of lower/upper case problem during installation - if on mac skip this part !